### PR TITLE
Gaddison/sw 1955 add non animation move to sequence builder

### DIFF
--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
@@ -171,10 +171,8 @@ class SequenceBuilder:
             horizontal: target body horizontal displacement, in meters. Clamped to
                 [-0.4, 0.4]. Default is 0.05.
             roll: target body roll, in radians. Clamped to [-0.2, 0.2]. Default is 0.00.
-            pivot: which portion of the body remains stationary. 0 = front, 2 = hind,
-                3 = center. Default is center.
-            style: the velocity profile of the move. 1 = standard, 2 = fast_out,
-                3 = fast_return, 4 = square, 5 = spike, 6 = plateau. Default is standard.
+            pivot: which portion of the body remains stationary, of type Pivot enum.
+            style: the velocity profile of the move, of type SwayParams.SwayStyle enum.
             pronounced: how exaggerated the style is. The closer to 0, the closer to
                 standard style. Clamped to [0.0, 1.0]. Default is 0.5.
             hold_zero_axes: whether to maintain the previous position and rotation for

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
@@ -195,8 +195,6 @@ class SequenceBuilder:
         vertical = max(min(roll, 0.2), -0.2)
         horizontal = max(min(horizontal, 0.4), -0.4)
         roll = max(min(roll, 0.2), -0.2)
-        pivot = int(max(min(pivot, 3), 1))
-        style = int(max(min(style, 6), 1))
         pronounced = max(min(pronounced, 1.0), 0.0)
 
         # Construct the move-specific parameters

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
@@ -2,9 +2,16 @@
 
 import copy
 import logging
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
-from bosdyn.api.spot.choreography_params_pb2 import AnimateParams, TwerkParams
+from bosdyn.api.spot.choreography_params_pb2 import (
+    AnimateParams,
+    BourreeParams,
+    Pivot,
+    RotateBodyParams,
+    SwayParams,
+    TwerkParams,
+)
 from bosdyn.api.spot.choreography_sequence_pb2 import (
     Animation,
     ChoreographySequence,
@@ -85,23 +92,163 @@ class SequenceBuilder:
         # Add to the sequence
         self._sequence.moves.append(move_params)
 
-    def add_twerk(self, twerk_params: TwerkParams, start_time: float, duration_sec: float) -> None:
-        """Add a twerk to the sequence"""
-        if twerk_params is None:
-            if self._logger is not None:
-                self._logger.error("Can't add TwerkParams None to sequence")
-            return
-        if not twerk_params.height:
-            if self._logger is not None:
-                self._logger.error("TwerkParams height is empty, can't add to sequence")
-            return
+    def add_rotate_body(
+        self,
+        start_sec: float,
+        duration_sec: float,
+        roll: float = 0.05,
+        pitch: float = 0.05,
+        yaw: float = 0.00,
+        return_to_start_pose: bool = True,
+    ) -> None:
+        """
+        Add a rotate_body to the sequence
+
+        Args:
+            start_sec: absolute time stamp at which point the move should start, in seconds.
+            duration_sec: duration of the move, in seconds. This will repeat the move.
+            roll: target body roll, in radians. Clamped to [-0.5, 0.5]. Default is 0.05.
+            pitch: target body pitch, in radians. Clamped to [-0.5, 0.5]. Default is 0.05.
+            yaw: target body yaw, in radians. Clamped to [-0.5, 0.5]. Default is 0.00.
+            return_to_start_pose: will return body to the previous pose by the end of this move.
+
+        Returns:
+            None
+        """
 
         # Re-frame from time to slices
         slices_per_second = self._sequence.slices_per_minute / 60
-        start_slice = int(start_time * slices_per_second)
+        start_slice = int(start_sec * slices_per_second)
 
         # Calculate the slices to request based on duration
         requested_slices = max(int(duration_sec * slices_per_second), 1)
+
+        # Sanitize inputs
+        start_sec = max(start_sec, 0)
+        duration_sec = max(start_sec, 0)
+        roll = max(min(roll, 0.5), -0.5)
+        pitch = max(min(pitch, 0.5), -0.5)
+        yaw = max(min(yaw, 0.5), -0.5)
+
+        # Construct the move-specific parameters
+        rotate_body_params = RotateBodyParams()
+        rotate_body_params.EulerZYXValue.roll.value = roll
+        rotate_body_params.EulerZYXValue.pitch.value = pitch
+        rotate_body_params.EulerZYXValue.yaw.value = yaw
+        rotate_body_params.return_to_start_pose.value = return_to_start_pose
+
+        # Set up its role within the sequence
+        move_params = MoveParams()
+        move_params.type = "rotate_body"
+        move_params.start_slice = start_slice
+        move_params.requested_slices = requested_slices
+        move_params.rotate_body_params.CopyFrom(rotate_body_params)
+
+        # Add to the sequence
+        self._sequence.moves.append(move_params)
+
+    def add_sway(
+        self,
+        start_sec: float,
+        duration_sec: float,
+        vertical: float = 0.00,
+        horizontal: float = 0.05,
+        roll: float = 0.00,
+        pivot: Any = Pivot.PIVOT_CENTER,  # since Pivot is a non-single protobuf type, we must use Any
+        style: Any = SwayParams.SwayStyle.SWAY_STYLE_STANDARD,
+        pronounced: float = 0.5,
+        hold_zero_axes: bool = False,
+    ) -> None:
+        """
+        Add a sway to the sequence
+
+        Args:
+            start_sec: absolute time stamp at which point the move should start,
+                in seconds.
+            duration_sec: duration of the move, in seconds. This will repeat the move.
+            vertical: target body vertical displacement, in meters. Clamped to
+                [-0.2, 0.2]. Default is 0.00.
+            horizontal: target body horizontal displacement, in meters. Clamped to
+                [-0.4, 0.4]. Default is 0.05.
+            roll: target body roll, in radians. Clamped to [-0.2, 0.2]. Default is 0.00.
+            pivot: which portion of the body remains stationary. 0 = front, 2 = hind,
+                3 = center. Default is center.
+            style: the velocity profile of the move. 1 = standard, 2 = fast_out,
+                3 = fast_return, 4 = square, 5 = spike, 6 = plateau. Default is standard.
+            pronounced: how exaggerated the style is. The closer to 0, the closer to
+                standard style. Clamped to [0.0, 1.0]. Default is 0.5.
+            hold_zero_axes: whether to maintain the previous position and rotation for
+                any axes set to 0. Default is False.
+
+        Returns:
+            None
+        """
+
+        # Re-frame from time to slices
+        slices_per_second = self._sequence.slices_per_minute / 60
+        start_slice = int(start_sec * slices_per_second)
+
+        # Calculate the slices to request based on duration
+        requested_slices = max(int(duration_sec * slices_per_second), 1)
+
+        # Sanitize inputs
+        start_sec = max(start_sec, 0)
+        duration_sec = max(start_sec, 0)
+        vertical = max(min(roll, 0.2), -0.2)
+        horizontal = max(min(horizontal, 0.4), -0.4)
+        roll = max(min(roll, 0.2), -0.2)
+        pivot = int(max(min(pivot, 3), 1))
+        style = int(max(min(style, 6), 1))
+        pronounced = max(min(pronounced, 1.0), 0.0)
+
+        # Construct the move-specific parameters
+        sway_params = SwayParams()
+        sway_params.vertical.value = vertical
+        sway_params.horizontal.value = horizontal
+        sway_params.roll.value = roll
+        sway_params.pivot = pivot
+        sway_params.style = style
+        sway_params.pronounced.value = pronounced
+        sway_params.hold_zero_axes.value = hold_zero_axes
+
+        # Set up its role within the sequence
+        move_params = MoveParams()
+        move_params.type = "sway"
+        move_params.start_slice = start_slice
+        move_params.requested_slices = requested_slices
+        move_params.sway_params.CopyFrom(sway_params)
+
+        # Add to the sequence
+        self._sequence.moves.append(move_params)
+
+    def add_twerk(self, start_sec: float, duration_sec: float, height: float = 0.05) -> None:
+        """
+        Add a twerk to the sequence
+
+        Args:
+            start_sec: absolute time stamp at which point the move should start, in seconds.
+            duration_sec: duration of the move, in seconds. This will repeat the move.
+            height: target twerk vertical displacement, in meters. Clamped to [0.0, 0.2]. Default is 0.1.
+
+        Returns:
+            None
+        """
+
+        # Re-frame from time to slices
+        slices_per_second = self._sequence.slices_per_minute / 60
+        start_slice = int(start_sec * slices_per_second)
+
+        # Calculate the slices to request based on duration
+        requested_slices = max(int(duration_sec * slices_per_second), 1)
+
+        # Sanitize inputs
+        start_sec = max(start_sec, 0)
+        duration_sec = max(start_sec, 0)
+        height = max(min(height, 0.2), 0.0)
+
+        # Construct the move-specific parameters
+        twerk_params = TwerkParams()
+        twerk_params.height.value = height
 
         # Set up its role within the sequence
         move_params = MoveParams()
@@ -109,6 +256,62 @@ class SequenceBuilder:
         move_params.start_slice = start_slice
         move_params.requested_slices = requested_slices
         move_params.twerk_params.CopyFrom(twerk_params)
+
+        # Add to the sequence
+        self._sequence.moves.append(move_params)
+
+    def add_bourree(
+        self,
+        start_sec: float,
+        duration_sec: float,
+        velocity_x: float = 0.00,
+        velocity_y: float = 0.00,
+        yaw_rate: float = 0.05,
+        stance_length: float = 0.00,
+    ) -> None:
+        """
+        Add a bourree to the sequence
+
+        Args:
+            start_sec: absolute time stamp at which point the move should start, in seconds.
+            duration_sec: duration of the move, in seconds. This will repeat the move.
+            velocity_x: target x (fore/aft) velocity, in m/s. Clamped to [-0.7, 0.7]. Default is 0.0.
+            velocity_y: target y (left/right) velocity, in m/s. Clamped to [-0.5, 0.5]. Default is 0.0.
+            yaw_rate: target yaw rate, in rad/s. Clamped to [-0.7, 0.7]. Default is 0.05.
+            stance_length: distance between front and hind legs. Clamped to [0.15, 0.80]. Default is 0.60.
+
+        Returns:
+            None
+        """
+
+        # Re-frame from time to slices
+        slices_per_second = self._sequence.slices_per_minute / 60
+        start_slice = int(start_sec * slices_per_second)
+
+        # Calculate the slices to request based on duration
+        requested_slices = max(int(duration_sec * slices_per_second), 1)
+
+        # Sanitize inputs
+        start_sec = max(start_sec, 0)
+        duration_sec = max(start_sec, 0)
+        velocity_x = max(min(velocity_x, 0.7), -0.7)
+        velocity_y = max(min(velocity_y, 0.5), -0.5)
+        yaw_rate = max(min(yaw_rate, 0.7), -0.7)
+        stance_length = max(min(stance_length, 0.8), 0.15)
+
+        # Construct the move-specific parameters
+        bourree_params = BourreeParams()
+        bourree_params.velocity.x.value = velocity_x
+        bourree_params.velocity.y.value = velocity_y
+        bourree_params.yaw_rate.value = yaw_rate
+        bourree_params.stance_length.value = stance_length
+
+        # Set up its role within the sequence
+        move_params = MoveParams()
+        move_params.type = "bourree"
+        move_params.start_slice = start_slice
+        move_params.requested_slices = requested_slices
+        move_params.bourree_params.CopyFrom(bourree_params)
 
         # Add to the sequence
         self._sequence.moves.append(move_params)


### PR DESCRIPTION
Added four functions in format `add_<move_type>()` that for four non-animation moves: sway, twerk, rotate_body, and bourree. These additionally include docstrings and input sanitization/clamping.

These behaviors were tested on hardware for basic functionality.