### PR TITLE
Optimize animation loop

### DIFF
--- a/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_backend.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_backend.py
@@ -461,7 +461,7 @@ def web_animation_loop(with_arm: bool = True) -> None:
                 print_current_pose_as_keyframe(animation_keyframe_map)
 
             if X_world_body.IsExactlyEqualTo(new_X_world_body):
-                time.sleep(1e-3)
+                time.sleep(0.016)
                 continue
 
             # Compute Ik.


### PR DESCRIPTION
## Problem
The animation loop with a sleep time of 1e-3 seconds (1000Hz) paradoxically causes sluggish UI response when moving sliders. The tight loop consumes excessive CPU resources and doesn't allow enough time for processing UI events. Updating at 1000Hz provides no visual benefit but consumes resources

## Solution
Increase the sleep time from 1e-3 seconds to 0.016 seconds (approximately 60Hz), which provides a better balance between animation smoothness and UI responsiveness.

## Testing
I tested several values between 0.016-0.05 seconds and found that 0.016 provides the best responsiveness animation on my system (WSL) and another device. This change makes slider movements react in real-time while maintaining smooth visual updates.

For comparison:
- 1e-3 (1000Hz): There is a delay between moving the slider and the actual movement
- 0.016s (60Hz): Very smooth but higher CPU usage
- 0.033s (30Hz): Good balance
- 0.05s (20Hz): Also works well