### PR TITLE
Gaddison/sw 2111 attempt an add move implementation that accepts list of moves

### DIFF
--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
@@ -124,7 +124,9 @@ class SequenceBuilder:
             if move_adder is not None:
                 move_adder(**move)
             else:
-                raise ValueError(f"Unsupported move type: {move_type}")
+                raise ValueError(
+                    f"spot_choreo_utils' AnimationBuilder does not yet support adding moves of type: {move_type}"
+                )
 
     def add_rotate_body(
         self,


### PR DESCRIPTION
Implemented an `add_moves()` function which takes a list of moves, each with move type and params, and adds them to the parent SequenceBuilder.

This was tested on hardware.