### PR TITLE
[N/A] Fix pre-performance for non-animation moves

### DIFF
--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
@@ -159,7 +159,7 @@ class SyncedSpotDancer(SyncedPerformanceModality):
         # If the sequence starts with a BOSDYN move, there's no need to set the robot pose
         # before the dance starts. If it starts with an animation, interpolate to the first
         # keyframe location so that the dance starts at the correct location
-        if self._sequence and self._sequence.moves[0].type != "animation":
+        if self._sequence is not None and self._sequence.moves[0].type != "animation":
             return True
 
         # Now upload and play a dance that is just the starting keyframe

--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
@@ -156,6 +156,12 @@ class SyncedSpotDancer(SyncedPerformanceModality):
         if not upload_result:
             return False
 
+        # If the sequence starts with a BOSDYN move, there's no need to set the robot pose
+        # before the dance starts. If it starts with an animation, interpolate to the first
+        # keyframe location so that the dance starts at the correct location
+        if self._sequence and self._sequence.moves[0].type != "animation":
+            return True
+
         # Now upload and play a dance that is just the starting keyframe
         # This ensures the robot always starts at the appropriate spot for the full dance
         sequence_name = self.prepare_dance_to_get_to_first_keyframe()


### PR DESCRIPTION
## Change Overview
Skip the preparation playback for bosdyn moves
  - Bosdyn moves don't need the preparation/interpolation that animations do