### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute, Inc.  All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute.  All rights reserved.
 
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Boston Dynamics AI Institute
+Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 FROM ubuntu:22.04
 
 USER root

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved
 
 # Update the developer docker user to match the UID and GID of the host user
 # This simplifies permissions with the mounted repo code

--- a/docker/start_docker.py
+++ b/docker/start_docker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright (c) 2024-2025  Boston Dynamics AI Institute LLC. All rights reserved.
 
 [build-system]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 # This empty file must exist for pyproject.toml to be used with setuptools

--- a/spot_choreo_utils/spot_choreo_utils/bosdyn_helpers.py
+++ b/spot_choreo_utils/spot_choreo_utils/bosdyn_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from bosdyn.api.robot_state_pb2 import RobotState
 from bosdyn.client import (

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import copy
 import math

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_operators.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_operators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import copy
 from logging import Logger

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_proto_utils.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/animation_proto_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 from typing import Any, Dict, Optional

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import copy
 import logging

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_operators.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/sequence_operators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from bosdyn.api.spot.choreography_sequence_pb2 import (
     MoveParams,

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/spot_properties.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/choreo_builders/spot_properties.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from itertools import chain
 from typing import Dict, List, Tuple

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/robot_pose_to_pose_utils.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/robot_pose_to_pose_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from collections import namedtuple
 from typing import Dict

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/semantic_animations/semantic_animation_builder.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/semantic_animations/semantic_animation_builder.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from logging import Logger

--- a/spot_choreo_utils/spot_choreo_utils/choreo_creation/semantic_animations/semantic_animation_operators.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_creation/semantic_animations/semantic_animation_operators.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import copy
 

--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_audio_player.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_audio_player.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import asyncio
 import subprocess

--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_performance_coordinator.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_performance_coordinator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import asyncio
 

--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_performance_modality.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_performance_modality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import sys
 from abc import abstractmethod

--- a/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
+++ b/spot_choreo_utils/spot_choreo_utils/choreo_playback/synced_spot_dancer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import asyncio
 import copy

--- a/spot_choreo_utils/spot_choreo_utils/paths.py
+++ b/spot_choreo_utils/spot_choreo_utils/paths.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from pathlib import Path
 

--- a/spot_choreo_utils/spot_choreo_utils/protos/regenerate_protos.py
+++ b/spot_choreo_utils/spot_choreo_utils/protos/regenerate_protos.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 #
 # Script that builds pb2 from .proto definitions.
 # This script creates a build directory structure that mirrors package needs

--- a/spot_choreo_utils/spot_choreo_utils/serialization/serialization_utils.py
+++ b/spot_choreo_utils/spot_choreo_utils/serialization/serialization_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import logging
 import os

--- a/spot_choreo_utils/test/test_animation_builder.py
+++ b/spot_choreo_utils/test/test_animation_builder.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 import copy
 import logging
 import unittest

--- a/spot_choreo_utils/test/test_animation_operators.py
+++ b/spot_choreo_utils/test/test_animation_operators.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 import logging
 import unittest
 

--- a/spot_choreo_utils/test/test_choreography_serialization_utils.py
+++ b/spot_choreo_utils/test/test_choreography_serialization_utils.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 import tempfile
 import unittest
 from pathlib import Path

--- a/spot_choreo_utils/test/test_semantic_animation_operators.py
+++ b/spot_choreo_utils/test/test_semantic_animation_operators.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 #
 # Functions that modify the contents of a semantic animation to accomplish a specific task
 # If a function is generally useful for keeping animations and their semantic data in sync

--- a/spot_choreo_utils/test/test_semantic_animation_wrapper.py
+++ b/spot_choreo_utils/test/test_semantic_animation_wrapper.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 import copy
 import tempfile
 import unittest

--- a/spot_choreo_utils/test/test_sequence_operators.py
+++ b/spot_choreo_utils/test/test_sequence_operators.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 import copy
 import unittest
 from pathlib import Path

--- a/spot_choreo_utils/test/test_synced_playback.py
+++ b/spot_choreo_utils/test/test_synced_playback.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#  Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import asyncio
 import time

--- a/spot_choreo_utils/web_animator/pyproject.toml
+++ b/spot_choreo_utils/web_animator/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 [build-system]
 requires = ["setuptools>=69.5.1", "setuptools-scm>=8.0"]

--- a/spot_choreo_utils/web_animator/spot_web_animator/animate.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/animate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from spot_web_animator.animation_backend.web_animator_backend import web_animation_loop
 

--- a/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_backend.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_backend.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright (c) 2024-2025  Boston Dynamics AI Institute LLC. All rights reserved.
 
 

--- a/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_drake_ui.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_drake_ui.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright (c) 2024-2025  Boston Dynamics AI Institute LLC. All rights reserved.
 
 from collections import namedtuple

--- a/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_serializer.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/animation_backend/web_animator_serializer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright (c) 2024-2025  Boston Dynamics AI Institute LLC. All rights reserved.
 
 from pathlib import Path

--- a/spot_choreo_utils/web_animator/spot_web_animator/systems/config/joint_configurations.yaml
+++ b/spot_choreo_utils/web_animator/spot_web_animator/systems/config/joint_configurations.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 base:
   stand:

--- a/spot_choreo_utils/web_animator/spot_web_animator/systems/helpers.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/systems/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import List, Optional
 

--- a/spot_choreo_utils/web_animator/spot_web_animator/systems/spot.py
+++ b/spot_choreo_utils/web_animator/spot_web_animator/systems/spot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from enum import Enum
 from pathlib import Path


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved.

This PR was created automatically.